### PR TITLE
Use xml-lens

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,6 @@
 
 { nixpkgs ? null
-, compiler ? "ghc844"
+, compiler ? "ghc864"
 }:
 
 let
@@ -8,24 +8,37 @@ let
     if isNull nixpkgs
       then
         builtins.fetchTarball {
-          # Recent version of nixpkgs-18.09 as of 2019-04-01.
-          url = "https://github.com/NixOS/nixpkgs/archive/3eed6d45739bfb6ef4e74837199021fe129a1f1f.tar.gz";
-          sha256 = "068zwvlhizayrz6hhkqhl0p9w97wqsi4yfphgq17p4xcvf997nw8";
+          # Recent version of nixpkgs-19.03 as of 2019-06-26.
+          url = "https://github.com/NixOS/nixpkgs/archive/8634c3b619909db7fc747faf8c03592986626e21.tar.gz";
+          sha256 = "sha256:0hcpy4q64vbqmlmnfcavfxilyygyzpwdsss8g3p73ikpic0j6ziq";
         }
       else
         nixpkgs;
-  pkgs = import nixpkgsSrc {};
-in
 
-with pkgs;
+  daimustOverlay = self: super: {
+    haskell = super.haskell // {
+      # Add a daimust attribute for every haskell package set.
+      packageOverrides = hself: hsuper:
+        super.haskell.packageOverrides hself hsuper // {
+          daimust = hself.developPackage {
+            name = "daimust";
+            root =
+              builtins.filterSource
+                (path: type: with self.stdenv.lib;
+                  ! elem (baseNameOf path) [ ".git" "result" ".stack-work" ] &&
+                  ! any (flip hasPrefix (baseNameOf path)) [ "dist" ".ghc" ]
+                )
+                ./.;
+          };
+        };
+    };
 
-let
-  diamust = haskell.packages.${compiler}.developPackage {
-    root = ./.;
-    modifier = drv: haskell.lib.overrideCabal drv (oldAttrs: {
-      doCheck = false;
-    });
+    daimust =
+      self.haskell.lib.justStaticExecutables
+        self.haskell.packages.${compiler}.daimust;
   };
+
+  pkgs = import nixpkgsSrc { overlays = [daimustOverlay]; };
 in
 
-diamust
+pkgs.daimust

--- a/package.yaml
+++ b/package.yaml
@@ -24,6 +24,7 @@ dependencies:
   - extensible
   - filepath
   - formatting
+  - html-conduit
   - http-client
   - http-client-tls
   - lens
@@ -50,7 +51,8 @@ dependencies:
   - unordered-containers
   - vector
   - wreq
-  - xml-html-conduit-lens
+  - xml-conduit
+  - xml-lens
 
 default-extensions:
   - AutoDeriveTypeable

--- a/src/Daimust/Crawler/Lens.hs
+++ b/src/Daimust/Crawler/Lens.hs
@@ -105,7 +105,7 @@ innerText = dom . folding universe . text . to (unwords . words)
 
 
 unescapeHtmlEntity :: Text -> Text
-unescapeHtmlEntity = view (to (encodeUtf8 . fromStrict) . html . text)
+unescapeHtmlEntity = view $ to (encodeUtf8 . fromStrict) . html . text
 
 html :: Fold LByteString Xml.Element
 html = to parseLBS . root

--- a/src/Daimust/Crawler/Lens.hs
+++ b/src/Daimust/Crawler/Lens.hs
@@ -7,7 +7,9 @@ import Control.Lens (Fold, Prism', filtered, folded, folding, ix, only, prism,
                      to, universe, view, (^.), (^..), (^?), _Just)
 import qualified Data.Map as Map
 import Network.URI
-import Text.Xml.Lens (attr, attributed, html, name, named, text)
+import Text.HTML.DOM (parseLBS)
+import qualified Text.XML as Xml
+import Text.XML.Lens (attribute, attributeIs, attributeSatisfies, ell, localName, root, text)
 
 import Daimust.Crawler.DomSelector
 import Daimust.Crawler.Type
@@ -20,11 +22,11 @@ _URI = prism tshow $ \s -> maybe (Left s) Right (parseURIReference $ unpack s)
 selected :: DomSelector -> Fold Dom Dom
 selected (DomSelector factors) = folding universe . filtered' factors
   where
+    filtered' :: [DomFactor] -> Fold Dom Dom
     filtered' [] = filtered (const True)
-    filtered' (DomName x : xs) = named (only name') . filtered' xs
-      where name' = fromString $ unpack x
-    filtered' (DomId x : xs) = attributed (ix "id" . only x) . filtered' xs
-    filtered' (DomClass x : xs) = attributed (ix "class" . to words . folded . only x) . filtered' xs
+    filtered' (DomName x : xs) = ell x . filtered' xs
+    filtered' (DomId x : xs) = attributeIs "id" x . filtered' xs
+    filtered' (DomClass x : xs) = attributeSatisfies "class" (\att -> x `elem` words att) . filtered' xs
 
 
 forms :: Fold Dom Form
@@ -35,20 +37,20 @@ _Form = prism (^. dom) $ \s -> maybe (Left s) Right (toForm s)
 
 toForm :: Dom -> Maybe Form
 toForm element = do
-  guard $ element ^. name == "form"
+  guard $ element ^. localName == "form"
   pure $ Form (fromMaybe emptyUrl action') fields' element
   where
-    action' = element ^? attr "action" . _Just . to unescapeHtmlEntity . _URI
+    action' = element ^? attribute "action" . _Just . to unescapeHtmlEntity . _URI
 
     fields' = Map.fromList $ inputs' <> options'
     inputs' = element ^.. inputs . to (view key &&& view value)
 
-    selects' = element ^.. selected "select" . attributed (ix "name")
+    selects' = element ^.. selected "select" . attributeSatisfies "name" (const True)
     options' = do
       e <- selects'
       maybe [] pure $ do
-        k <- e ^. attr "name"
-        v <- e ^. selected "option" . attributed (ix "selected") . attr "value"
+        k <- e ^. attribute "name"
+        v <- e ^. selected "option" . attributeSatisfies "selected" (const True) . attribute "value"
         pure (k, v)
 
     emptyUrl = URI "" Nothing "" "" ""
@@ -62,10 +64,10 @@ _Input = prism (^. dom) $ \s -> maybe (Left s) Right (toInput s)
 
 toInput :: Dom -> Maybe Input
 toInput element = do
-  name' <- element ^. attr "name"
+  name' <- element ^. attribute "name"
   pure $ Input name' value' element
   where
-    value' = element ^. attr "value" . folded
+    value' = element ^. attribute "value" . folded
 
 
 links :: Fold Dom Link
@@ -76,7 +78,7 @@ _Link = prism (^. dom) $ \s -> maybe (Left s) Right (toLink s)
 
 toLink :: Dom -> Maybe Link
 toLink element = do
-  href' <- element ^? attr "href" . _Just . to unescapeHtmlEntity . _URI
+  href' <- element ^? attribute "href" . _Just . to unescapeHtmlEntity . _URI
   pure $ Link href' element
 
 
@@ -88,19 +90,22 @@ _Frame = prism (^. dom) $ \s -> maybe (Left s) Right (toFrame s)
 
 toFrame :: Dom -> Maybe Frame
 toFrame element = do
-  src' <- element ^? attr "src" . _Just . to unescapeHtmlEntity . _URI
+  src' <- element ^? attribute "src" . _Just . to unescapeHtmlEntity . _URI
   pure $ Frame src' element
 
 
 domId :: (HasDom s Dom) => Fold s Text
-domId = dom . attr "id" . folded
+domId = dom . attribute "id" . folded
 
 domClass :: (HasDom s Dom) => Fold s Text
-domClass = dom . attr "class" . folded . to words . folded
+domClass = dom . attribute "class" . folded . to words . folded
 
 innerText :: (HasDom s Dom) => Fold s Text
 innerText = dom . folding universe . text . to (unwords . words)
 
 
 unescapeHtmlEntity :: Text -> Text
-unescapeHtmlEntity = view $ to (encodeUtf8 . fromStrict) . html . text
+unescapeHtmlEntity = view (to (encodeUtf8 . fromStrict) . html . text)
+
+html :: Fold LByteString Xml.Element
+html = to parseLBS . root

--- a/src/Daimust/Crawler/Type.hs
+++ b/src/Daimust/Crawler/Type.hs
@@ -31,11 +31,10 @@ import Control.Lens (makeFields)
 import qualified Data.ByteString.Lazy as BL
 import Network.URI (URI)
 import qualified Network.Wreq as Wreq
-import qualified Text.Xml.Lens as Xml
-
+import qualified Text.XML as XML
 
 type Response = Wreq.Response BL.ByteString
-type Dom = Xml.Element
+type Dom = XML.Element
 
 data Form = Form
   { _formAction :: URI

--- a/src/Daimust/Crawler/Utils.hs
+++ b/src/Daimust/Crawler/Utils.hs
@@ -8,22 +8,33 @@ where
 import ClassyPrelude
 
 import Control.Lens (to, (.~), (^.))
+import Data.Default (def)
 import qualified Data.Map as Map
-import Text.Xml.Lens as Xml
+import Text.XML (Document(Document), Prologue(Prologue), rsPretty, renderLBS)
+import qualified Text.XML as Xml
+import Text.XML.Lens (localName)
 
-import Daimust.Crawler.Lens
-import Daimust.Crawler.Type
+import Daimust.Crawler.Lens (domClass, domId, innerText)
+import Daimust.Crawler.Type (Form, Link, action, dom, fields, href)
 
 
 -- * Formmatting dom element
 
 formatElement :: Xml.Element -> Text
-formatElement x = toStrict $ x ^. Xml.renderWith (rsPretty .~ True)
+-- formatElement x = toStrict $ x ^. Xml.renderWith (rsPretty .~ True)
+formatElement x =
+  let renderSettings = def { rsPretty = True }
+      doc = elementToDocument x
+      rendered = renderLBS renderSettings doc
+  in decodeUtf8 $ toStrict rendered
+
+elementToDocument :: Xml.Element -> Document
+elementToDocument e = Document (Prologue [] Nothing []) e []
 
 formatForm :: Form -> [Text]
 formatForm form =
   [ mconcat
-    [ form ^. dom . name
+    [ form ^. dom . localName
     , form ^. domId . to ("#" <>)
     , form ^. domClass . to ("." <>)
     ]
@@ -35,7 +46,7 @@ formatForm form =
 formatLink :: Link -> Text
 formatLink link' =
   mconcat
-  [ link' ^. dom . name
+  [ link' ^. dom . localName
   , link' ^. domId . to ("#" <>)
   , link' ^. domClass . to ("." <>)
   ]

--- a/src/Daimust/Crawler/Utils.hs
+++ b/src/Daimust/Crawler/Utils.hs
@@ -21,7 +21,6 @@ import Daimust.Crawler.Type (Form, Link, action, dom, fields, href)
 -- * Formmatting dom element
 
 formatElement :: Xml.Element -> Text
--- formatElement x = toStrict $ x ^. Xml.renderWith (rsPretty .~ True)
 formatElement x =
   let renderSettings = def { rsPretty = True }
       doc = elementToDocument x

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,7 +4,4 @@ packages:
   - .
 
 extra-deps:
-  - xml-html-conduit-lens-0.3.2.4
   - extensible-0.5
-  - containers-0.5.11.0
-

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,2 +1,6 @@
+module Main where
+
+import ClassyPrelude
+
 main :: IO ()
 main = say "Test suite not yet implemented"


### PR DESCRIPTION
This updates daimust to use the `xml-lens` package instead of xml-html-conduit-lens.

As far as I'm aware, the `xml-lens` package from fumieval is the standard package providing lenses for working with XML.  `xml-html-conduit-lens` appears to not be kept up-to-date with the latest GHC releases.

This also updates the nix building stuff.